### PR TITLE
Make regex matches in group instead of capture ref

### DIFF
--- a/src/components/editor/editor.js
+++ b/src/components/editor/editor.js
@@ -104,7 +104,7 @@ class PageContainer extends React.Component {
             newContentState = Modifier.replaceText(
               newContentState,
               selection,
-              match[1]
+              match.groups.text
             );
 
             //We create a second selection as this needs to have a different offset because the string is now 

--- a/src/components/editor/styleMap.js
+++ b/src/components/editor/styleMap.js
@@ -1,9 +1,8 @@
 const styleMap = {
-    'MYSTYLE1': {
+    'bold': {
         fontWeight: 'bold',
-        fontStyle: 'italic',
-        regEx: /\*(.*?)\*/g,
-        keyCharsCount: 1 //This is the number of characters in the key, 1 for * and 2 for **
+        regEx: /\*{2}(.*?)\*{2}/g,
+        keyCharsCount: 2 //This is the number of characters in the key, 1 for * and 2 for **
     },
     'MYSTYLE2': {
         textDecoration: 'line-through',

--- a/src/components/editor/styleMap.js
+++ b/src/components/editor/styleMap.js
@@ -1,17 +1,17 @@
 const styleMap = {
     'bold': {
         fontWeight: 'bold',
-        regEx: /\*{2}(.*?)\*{2}/g,
+        regEx: /\*{2}(?<text>.*?)\*{2}/g,
         keyCharsCount: 2 //This is the number of characters in the key, 1 for * and 2 for **
     },
     'MYSTYLE2': {
         textDecoration: 'line-through',
-        regEx: /\-(.*?)\-/g,
+        regEx: /\-(?<text>.*?)\-/g,
         keyCharsCount: 1
     },
     'MYSTYLE3': {
         color: 'red',
-        regEx: /\+\+\+(.*?)\+\+\+/g,
+        regEx: /\+\+\+(?<text>.*?)\+\+\+/g,
         keyCharsCount: 3
     },
 };


### PR DESCRIPTION
This allows for more readability in the code and more freedom later to
use capture groups, lookaheads, lookbehinds for more precise matching.